### PR TITLE
Added strict sorting for sortInventory(inv, startSlot, endSlot)

### DIFF
--- a/src/de/jeffclan/JeffChestSort/JeffChestSortPlugin.java
+++ b/src/de/jeffclan/JeffChestSort/JeffChestSortPlugin.java
@@ -1,13 +1,6 @@
 package de.jeffclan.JeffChestSort;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
+import de.jeffclan.utils.Utils;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -15,7 +8,13 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import de.jeffclan.utils.Utils;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 public class JeffChestSortPlugin extends JavaPlugin {
 
@@ -37,6 +36,10 @@ public class JeffChestSortPlugin extends JavaPlugin {
 	
 	public void sortInventory(Inventory inv, int startSlot, int endSlot) {
 		this.organizer.sortInventory(inv,startSlot,endSlot);
+	}
+
+	public void sortInventoryStrict(Inventory inv, int startSlot, int endSlot) {
+		this.organizer.sortInventoryStrict(inv,startSlot,endSlot);
 	}
 	
 	void createConfig() {


### PR DESCRIPTION
I noticed what you meant about items not stacking when using `setItem`.
So my only solution would to be stacking the items before sorting.

At first I was going to create my own method of stacking items but figured I wouldn't reinvent the wheel because `Inventory.addItem` already does exactly that.

So I ended up using `Bukkit.createInventory` to create a temp inventory with a null holder and a size of 54 (which should fit most needs) and returning the contents of that inventory to be using in the sorting.

I still end up using `setItem` because we want it to stay within the `startSlot` and `endSlot` range.

I tested this multiple times and didn't have problems.

A fix for https://github.com/JEFF-Media-GbR/Spigot-ChestSort/issues/5