### PR TITLE
4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>de.jeffclan</groupId>
 	<artifactId>JeffChestSort</artifactId>
-	<version>4.0</version>
+	<version>4.1-beta2</version>
 	<packaging>jar</packaging>
 
 	<name>JeffChestSort</name>

--- a/src/main/java/de/jeffclan/JeffChestSort/JeffChestSortCommandExecutor.java
+++ b/src/main/java/de/jeffclan/JeffChestSort/JeffChestSortCommandExecutor.java
@@ -1,5 +1,6 @@
 package de.jeffclan.JeffChestSort;
 
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -51,7 +52,26 @@ public class JeffChestSortCommandExecutor implements CommandExecutor {
 			
 			Player p = (Player) sender;
 			
-			plugin.sortInventory(p.getInventory(), 9, 35);
+			int start = 9;
+			int end = 35;
+			
+			if(args.length>0) {
+				if(args[0].equalsIgnoreCase("all")) {
+					start=0;
+					end=35;
+				} else if(args[0].equalsIgnoreCase("hotbar")) {
+					start=0;
+					end=8;
+				} else if(args[0].equalsIgnoreCase("inv")) {
+					start=9;
+					end=35;
+				} else {
+					p.sendMessage(ChatColor.RED+"Error: unknown option \""+args[0]+"\". Valid values are \"inv\", \"hotbar\" and \"all\".");
+					return true;
+				}
+			}
+			
+			plugin.sortInventory(p.getInventory(), start, end);
 			p.sendMessage(plugin.messages.MSG_PLAYERINVSORTED);
 			
 			return true;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -130,6 +130,7 @@ message-player-inventory-sorted: "&7Your inventory has been sorted."
 #message-sorting-disabled: "&7自动整理箱子已 &c关闭&7."
 #message-sorting-enabled: "&7自动整理箱子已 &a启用&7."
 #message-error-players-only: "&c错误: 指令只能由玩家运行."
+#message-player-inventory-sorted: "&7Your inventory has been sorted."
 
 ##### Chinese (Traditional) 繁體中文
 #message-when-using-chest: "&7小提醒: 輸入 &6/chestsort&7 來開啟自動整理箱子"
@@ -137,6 +138,7 @@ message-player-inventory-sorted: "&7Your inventory has been sorted."
 #message-sorting-disabled: "&7自動整理箱子已 &c關閉&7"
 #message-sorting-enabled: "&7自動整理箱子已 &a開啟&7"
 #message-error-players-only: "&c錯誤: 這個指令只能由玩家使用"
+#message-player-inventory-sorted: "&7Your inventory has been sorted."
 
 ##### French - Thanks to automatizer for translating! -> https://www.spigotmc.org/members/automatizer.26188/
 #message-when-using-chest: "&7Astuce: Écris &6/chestsort&7 pour activer le classement automatique."
@@ -144,6 +146,7 @@ message-player-inventory-sorted: "&7Your inventory has been sorted."
 #message-sorting-disabled: "&7Le classement automatique a été &cdésactivé&7."
 #message-sorting-enabled: "&7Le classement automatique a été &aactivé&7."
 #message-error-players-only: "&cErreur: Cette commande ne peut être utilisée que par des joueurs."
+#message-player-inventory-sorted: "&7Your inventory has been sorted."
 
 ##### German
 #message-when-using-chest: "&7Hinweis: Benutze &6/chestsort&7 um die automatische Kistensortierung zu aktivieren."
@@ -151,6 +154,7 @@ message-player-inventory-sorted: "&7Your inventory has been sorted."
 #message-sorting-disabled: "&7Automatische Kistensortierung &cdeaktiviert&7."
 #message-sorting-enabled: "&7Automatische Kistensortierung &aaktiviert&7."
 #message-error-players-only: "&cFehler: Dieser Befehl ist nur für Spieler verfügbar."
+#message-player-inventory-sorted: "&7Dein Inventar wurde sortiert.."
 
 ##### Italian - Translated with Google. Please tell me if something is wrong :)
 #message-when-using-chest: "&7Nota: inserire &6/chestsort&7 per abilitare l'ordinamento automatico dei bauli."
@@ -158,6 +162,7 @@ message-player-inventory-sorted: "&7Your inventory has been sorted."
 #message-sorting-disabled: "&7L'ordinamento automatico dei bauli è stato &cdisattivato&7."
 #message-sorting-enabled: "&7L'ordinamento automatico dei bauli è stato &aattivato&7."
 #message-error-players-only: "&cErrore: questo comando è disponibile solo per i giocatori."
+#message-player-inventory-sorted: "&7Your inventory has been sorted."
 
 ##### Japanese
 #message-when-using-chest: "&7ヒント: &6/chestsort&7 と入力して自動チェスト整理を有効にできます。"
@@ -165,7 +170,15 @@ message-player-inventory-sorted: "&7Your inventory has been sorted."
 #message-sorting-disabled: "&7自動チェスト整理は現在 &cOFF&7です。"
 #message-sorting-enabled: "&7自動チェスト整理は現在 &aON&7です。"
 #message-error-players-only: "&cエラー: このコマンドはプレイヤーのみ実行できます。"
+#message-player-inventory-sorted: "&7Your inventory has been sorted."
 
+##### Portuguese - Thanks to wildastral for translating! -> https://www.spigotmc.org/members/wildastral.673147/
+#message-when-using-chest: "&7Dica: Digite &6/chestsort&7 para habilitar a organização automática."
+#message-when-using-chest2: "&7Dica: Digite &6/chestsort&7 para desabilitar a organização automática."
+#message-sorting-disabled: "&7A Organização automática de baús foi &cdesabilitada&7."
+#message-sorting-enabled: "&7A Organização automática de baús foi &ahabilitada&7."
+#message-error-players-only: "&cErro: Esse comando não pode ser executado por jogadores."
+#message-player-inventory-sorted: "&7Seu inventário foi organizado." 
 
 ##### Russian - Thanks to Gandon for translating! -> https://www.spigotmc.org/members/gandon.443887/
 #message-when-using-chest: "&7Подсказка: введите &6"/chestsort&7, чтобы включить автоматическую сортировку вещей в сундуках."
@@ -173,6 +186,7 @@ message-player-inventory-sorted: "&7Your inventory has been sorted."
 #message-sorting-disabled: "&7Автоматическая сортировка вещей в сундуках была &cотключена&7."
 #message-sorting-enabled: "&7Автоматическая сортировка вещей в сундуках была &aвключена&7."
 #message-error-players-only: "&cОшибка: эта команда может быть использована только игроками."
+#message-player-inventory-sorted: "&7Your inventory has been sorted."
 
 ##### Spanish - Thanks to Bers_ for translating! ->  https://www.spigotmc.org/members/bers_.146126/
 #message-when-using-chest: "&7Pista: Usa &6/chestsort&7 para activar el orden automático de los cofres."
@@ -180,6 +194,7 @@ message-player-inventory-sorted: "&7Your inventory has been sorted."
 #message-sorting-disabled: "&7Orden automático de los cofres &cdesactivado&7."
 #message-sorting-enabled: "&7Orden automático de los cofres &aactivado&7."
 #message-error-players-only: "&cError: Este comando solo puede ser ejecutado por jugadores."
+#message-player-inventory-sorted: "&7Your inventory has been sorted."
 
 #########################
 #####     Done!     #####

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 main: de.jeffclan.JeffChestSort.JeffChestSortPlugin
 name: ChestSort
-version: 4.0
+version: 4.1-beta2
 api-version: 1.13
 description: Allows automatic chest sorting
 author: mfnalex
@@ -16,8 +16,8 @@ commands:
     aliases: sort
     permission: chestsort.use
   invsort:
-    description: Sorts the player's inventory except hotbar, armor slots and items in hands
-    usage: /<command>
+    description: Sorts the player's inventory. When no option is specified, only the regular inventory (excluding the hotbar) is sorted.
+    usage: /<command> [inv|hotbar|all]
     aliases: [isort,inventorysort]
     permission: chestsort.use.inventory
 permissions:


### PR DESCRIPTION
adds options to /invsort

/invsort without options equals to /invsort inv
/invsort inv will sort the regular player inventory (excluding hotbar and armor slots)
/invsort hotbar will sort the hotbar only
/invsort all will sort the inventory and hotbar