### PR TITLE
Add EnderContainers support

### DIFF
--- a/src/main/java/de/jeff_media/ChestSort/ChestSortListener.java
+++ b/src/main/java/de/jeff_media/ChestSort/ChestSortListener.java
@@ -158,7 +158,10 @@ public class ChestSortListener implements Listener {
         Player p = (Player) event.getPlayer();
         Inventory inventory = event.getInventory();
 
-        if (!isAPICall(inventory) && !belongsToChestLikeBlock(inventory) && !LlamaUtils.belongsToLlama(inventory)) {
+        if (!isAPICall(inventory)
+                && !belongsToChestLikeBlock(inventory)
+                && !plugin.enderContainersHook.isEnderchest(inventory)
+                && !LlamaUtils.belongsToLlama(inventory)) {
             return;
         }
 
@@ -205,7 +208,10 @@ public class ChestSortListener implements Listener {
         Player p = (Player) event.getPlayer();
         Inventory inventory = event.getInventory();
 
-        if (!isAPICall(inventory) && !belongsToChestLikeBlock(inventory) && !LlamaUtils.belongsToLlama(inventory)) {
+        if (!isAPICall(inventory)
+                && !belongsToChestLikeBlock(inventory)
+                && !plugin.enderContainersHook.isEnderchest(inventory)
+                && !LlamaUtils.belongsToLlama(inventory)) {
             return;
         }
 

--- a/src/main/java/de/jeff_media/ChestSort/ChestSortListener.java
+++ b/src/main/java/de/jeff_media/ChestSort/ChestSortListener.java
@@ -487,7 +487,8 @@ public class ChestSortListener implements Listener {
                 || belongsToChestLikeBlock(event.getClickedInventory())
                 || LlamaUtils.belongsToLlama(event.getClickedInventory())
                 || minepacksHook.isMinepacksBackpack(event.getClickedInventory())
-                || plugin.playerVaultsHook.isPlayerVault(event.getClickedInventory())) {
+                || plugin.playerVaultsHook.isPlayerVault(event.getClickedInventory())
+                || plugin.enderContainersHook.isEnderchest(event.getClickedInventory())) {
 
 
             if (!p.hasPermission("chestsort.use")) {

--- a/src/main/java/de/jeff_media/ChestSort/ChestSortPlugin.java
+++ b/src/main/java/de/jeff_media/ChestSort/ChestSortPlugin.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import de.jeff_media.ChestSort.config.Config;
+import de.jeff_media.ChestSort.hooks.EnderContainersHook;
 import de.jeff_media.ChestSort.hooks.GenericGUIHook;
 import de.jeff_media.ChestSort.hooks.PlayerVaultsHook;
 import de.jeff_media.ChestSort.placeholders.ChestSortPlaceholders;
@@ -86,7 +87,8 @@ public class ChestSortPlugin extends JavaPlugin implements de.jeff_media.ChestSo
 
 	public GenericGUIHook genericHook;
 	public PlayerVaultsHook playerVaultsHook;
-	
+	public EnderContainersHook enderContainersHook;
+
 	private static long updateCheckInterval = 4*60*60; // in seconds. We check on startup and every 4 hours
 	
 	String mcVersion; 	// 1.13.2 = 1_13_R2
@@ -519,6 +521,7 @@ public class ChestSortPlugin extends JavaPlugin implements de.jeff_media.ChestSo
 		updateCheckInterval = (int) (getConfig().getDouble("check-interval")*60*60);
 		sortingMethod = getConfig().getString("sorting-method");
 		playerVaultsHook = new PlayerVaultsHook(this);
+		enderContainersHook = new EnderContainersHook(this);
 		getServer().getPluginManager().registerEvents(listener, this);
 		getServer().getPluginManager().registerEvents(settingsGUI, this);
 		ChestSortChestSortCommand chestsortCommandExecutor = new ChestSortChestSortCommand(this);

--- a/src/main/java/de/jeff_media/ChestSort/hooks/EnderContainersHook.java
+++ b/src/main/java/de/jeff_media/ChestSort/hooks/EnderContainersHook.java
@@ -1,0 +1,23 @@
+package de.jeff_media.ChestSort.hooks;
+
+import de.jeff_media.ChestSort.ChestSortPlugin;
+import org.bukkit.inventory.Inventory;
+
+public class EnderContainersHook {
+
+    private static final String CLASS_NAME = "fr.utarwyn.endercontainers.inventory.EnderChestInventory";
+
+    private final ChestSortPlugin main;
+
+    public EnderContainersHook(ChestSortPlugin main) {
+        this.main = main;
+    }
+
+    public boolean isEnderchest(Inventory inv) {
+        if (inv == null) return false;
+        if (inv.getHolder() == null) return false;
+        if (!main.getConfig().getBoolean("hook-endercontainers", true)) return false;
+        return inv.getHolder().getClass().getName().equals(CLASS_NAME);
+    }
+
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -234,6 +234,11 @@ hook-minepacks: true
 # player vaults just like regular chests.
 hook-playervaults: true
 
+##### EnderContainers ##### -> https://www.spigotmc.org/resources/endercontainers.4750/
+# When EnderContainers version 2+ is installed, ChestSort can detect your
+# enderchests and sort them like a regular chest.
+hook-endercontainers: true
+
 ##### CrateReloaded #####
 # Prevents the player from using hotkeys on a crate
 hook-cratereloaded: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -235,8 +235,8 @@ hook-minepacks: true
 hook-playervaults: true
 
 ##### EnderContainers ##### -> https://www.spigotmc.org/resources/endercontainers.4750/
-# When EnderContainers version 2+ is installed, ChestSort can detect your
-# enderchests and sort them like a regular chest.
+# When EnderContainers version 2.2.1+ is installed, ChestSort can detect your
+# enderchests and sort them like regular chests.
 hook-endercontainers: true
 
 ##### CrateReloaded #####


### PR DESCRIPTION
Hello,

I discovered your project few weeks ago and I found it very interesting. I am also a plugin maker. As I am concerned about adding more integrations to my plugin [EnderContainers](https://github.com/utarwyn/Endercontainers), I would like to add possibility for server owners who also use your plugin to propose sorting (and auto-sorting) for EnderContainers inventories.

This PR brings that support into your plugin. It is fully working since **version 2.2.1** of my plugin. I have created a new hook to support my custom inventory holder that you can find here: https://github.com/utarwyn/EnderContainers/blob/v2.2.1/plugin/src/main/java/fr/utarwyn/endercontainers/inventory/EnderChestInventory.java

Tell me if my changes are ok,
Best regards